### PR TITLE
Support compiling with Clang

### DIFF
--- a/include/fastcgi++/manager.hpp
+++ b/include/fastcgi++/manager.hpp
@@ -169,6 +169,9 @@ namespace Fastcgipp
             return m_transceiver.listen(interface, service);
         }
 
+        //! Pass a message to a request
+        void push(Protocol::RequestId id, Message&& message);
+
     protected:
         //! Make a request object
         virtual std::unique_ptr<Request_base> makeRequest(
@@ -178,9 +181,6 @@ namespace Fastcgipp
 
         //! Handles low level communication with the other side
         Transceiver m_transceiver;
-
-        //! Pass a message to a request
-        void push(Protocol::RequestId id, Message&& message);
 
     private:
         //! Queue for pending tasks

--- a/src/http.cpp
+++ b/src/http.cpp
@@ -639,9 +639,9 @@ Fastcgipp::Http::SessionId::SessionId()
     m_timestamp = std::time(nullptr);
 }
 
-template Fastcgipp::Http::SessionId::SessionId<char>(
+template Fastcgipp::Http::SessionId::SessionId(
         const std::basic_string<char>& string);
-template Fastcgipp::Http::SessionId::SessionId<wchar_t>(
+template Fastcgipp::Http::SessionId::SessionId(
         const std::basic_string<wchar_t>& string);
 template<class charT> Fastcgipp::Http::SessionId::SessionId(
         const std::basic_string<charT>& string)
@@ -760,7 +760,7 @@ extern const std::array<const char, 64> Fastcgipp::Http::base64Characters =
 }};
 
 const std::array<const char* const, 9> Fastcgipp::Http::requestMethodLabels =
-{
+{{
     "ERROR",
     "HEAD",
     "GET",
@@ -770,7 +770,7 @@ const std::array<const char* const, 9> Fastcgipp::Http::requestMethodLabels =
     "TRACE",
     "OPTIONS",
     "CONNECT"
-};
+}};
 
 Fastcgipp::Http::Address& Fastcgipp::Http::Address::operator&=(
         const Address& x)
@@ -1258,7 +1258,7 @@ Fastcgipp::Http::operator>>(
 Fastcgipp::Http::Address::operator bool() const
 {
     static const std::array<const unsigned char, 16> nullString =
-        {0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0};
+        {{0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0}};
     if(std::equal(m_data.begin(), m_data.end(), nullString.begin()))
         return false;
     return true;

--- a/src/log.cpp
+++ b/src/log.cpp
@@ -87,14 +87,14 @@ namespace Fastcgipp
         }
 
         std::array<std::wstring, 6> levels
-        {
+        {{
             L"[info]: ",
             L"[fail]: ",
             L"[error]: ",
             L"[warning]: ",
             L"[debug]: ",
             L"[diagnostic]: "
-        };
+        }};
     }
 }
 

--- a/src/sockets.cpp
+++ b/src/sockets.cpp
@@ -384,7 +384,7 @@ Fastcgipp::Socket Fastcgipp::SocketGroup::connect(const char* name)
 
     return m_sockets.emplace(
             fd,
-            std::move(Socket(fd, *this))).first->second;
+            Socket(fd, *this)).first->second;
 }
 
 Fastcgipp::Socket Fastcgipp::SocketGroup::connect(
@@ -447,7 +447,7 @@ Fastcgipp::Socket Fastcgipp::SocketGroup::connect(
 
     return m_sockets.emplace(
             fd,
-            std::move(Socket(fd, *this))).first->second;
+            Socket(fd, *this)).first->second;
 }
 
 Fastcgipp::Socket Fastcgipp::SocketGroup::poll(bool block)
@@ -627,7 +627,7 @@ void Fastcgipp::SocketGroup::createSocket(const socket_t listener)
     {
         m_sockets.emplace(
                 socket,
-                std::move(Socket(socket, *this)));
+                Socket(socket, *this));
 #if FASTCGIPP_LOG_LEVEL > 3
         ++m_incomingConnectionCount;
 #endif


### PR DESCRIPTION
error: suggest braces around initialization of subobject [-Werror,-Wmissing-braces]

error: qualified reference to 'SessionId' is a constructor name rather than a type wherever a constructor can be declared

error: moving a temporary object prevents copy elision [-Werror,-Wpessimizing-move]

include/fastcgi++/manager.hpp:308:46: error: 'push' is a protected member of 'Fastcgipp::Manager_base'
                    std::bind(&Manager_base::push, this, id, _1));

"make test" passes under both g++ and clang after this pull request is applied.
