### PR TITLE
Problems with post content and http authentication header added

### DIFF
--- a/include/fastcgi++/http.hpp
+++ b/include/fastcgi++/http.hpp
@@ -260,7 +260,10 @@ namespace Fastcgipp
 
             //! Character sets the clients accepts
             std::basic_string<charT> acceptCharsets;
-
+	  
+            //! Http authorization string
+            std::basic_string<charT> authorization;
+	  
             //! Referral URL
             std::basic_string<charT> referer;
 

--- a/src/http.cpp
+++ b/src/http.cpp
@@ -339,6 +339,8 @@ template<class charT> void Fastcgipp::Http::Environment<charT>::fill(
         case 18:
             if(std::equal(name, value, "HTTP_IF_NONE_MATCH"))
                 etag=atoi(&*value, &*end);
+            else if(std::equal(name, value, "HTTP_AUTHORIZATION"))
+                vecToString(value, end, authorization);
             break;
         case 19:
             if(std::equal(name, value, "HTTP_ACCEPT_CHARSET"))

--- a/src/request.cpp
+++ b/src/request.cpp
@@ -128,7 +128,8 @@ std::unique_lock<std::mutex>Fastcgipp::Request<charT>::handler()
                             goto exit;
                         }
 
-                        m_environment.clearPostBuffer();
+                        if (!inProcessor())
+                           m_environment.clearPostBuffer();
                         m_state = Protocol::RecordType::OUT;
                         break;
                     }


### PR DESCRIPTION
I want to send application/json data as post content. But first the content is added successfully and in a second round in the request loop it is clear afterwards. I assumed this is the case because I return "true" inProcessor because I have to handle application/json content by myself. 

The second commit in this pull request just makes the HTTP_AUTHENTICATION header available in the environment because this is often used when implementing an oauth based API.

BTW. Nice rewrite, before trying out the new 3.0beta I was successfully using the old 2.x version. 