### PR TITLE
adding support for CORS Access-Control-Request header

### DIFF
--- a/include/fastcgi++/http.hpp
+++ b/include/fastcgi++/http.hpp
@@ -260,10 +260,16 @@ namespace Fastcgipp
 
             //! Character sets the clients accepts
             std::basic_string<charT> acceptCharsets;
-	  
+
+            //! CORS Access-Control-Request-Method
+            std::basic_string<charT> accessControlRequestMethod;
+
+            //! CORS Access-Control-Request-Headers
+            std::basic_string<charT> accessControlRequestHeaders;
+
             //! Http authorization string
             std::basic_string<charT> authorization;
-	  
+
             //! Referral URL
             std::basic_string<charT> referer;
 

--- a/src/http.cpp
+++ b/src/http.cpp
@@ -394,6 +394,14 @@ template<class charT> void Fastcgipp::Http::Environment<charT>::fill(
                 ifModifiedSince = std::mktime(&time) - timezone;
             }
             break;
+        case 34:
+            if(std::equal(name, value, "HTTP_ACCESS_CONTROL_REQUEST_METHOD"))
+                vecToString(value, end, accessControlRequestMethod);
+            break;
+        case 35:
+            if(std::equal(name, value, "HTTP_ACCESS_CONTROL_REQUEST_HEADERS"))
+                vecToString(value, end, accessControlRequestHeaders);
+            break;
         }
         data = end;
     }


### PR DESCRIPTION
Hi Eddie,

I have another small change, I had some issues with HTTP authentication and the need to have the Access-Control-Request-Method and AccessControlRequestHeaders Header inside the environment, otherwise my browser refuses to send my requests :-1: 
BTW. now that I'm making the call to postBuffer inside inProcessor it works flawless :1st_place_medal:  Thanks for your clarification.

Best regards
Mirko