### PR TITLE
Hacky json support

### DIFF
--- a/include/fastcgi++/http.hpp
+++ b/include/fastcgi++/http.hpp
@@ -393,6 +393,9 @@ namespace Fastcgipp
 
             //! Parses "application/x-www-form-urlencoded" post data
             inline void parsePostsUrlEncoded();
+            
+            //! Parses "application/json" post data
+            inline void parsePostsJSON();
 
             //! Raw string of characters representing the post boundary
             std::vector<char> boundary;

--- a/src/http.cpp
+++ b/src/http.cpp
@@ -421,6 +421,7 @@ template<class charT> bool Fastcgipp::Http::Environment<charT>::parsePostBuffer(
 {
     static const std::string multipartStr("multipart/form-data");
     static const std::string urlEncodedStr("application/x-www-form-urlencoded");
+    static const std::string JSONStr("application/json");
 
     if(!m_postBuffer.size())
         return true;
@@ -445,8 +446,34 @@ template<class charT> bool Fastcgipp::Http::Environment<charT>::parsePostBuffer(
         parsePostsUrlEncoded();
         parsed = true;
     }
+    else if(std::equal(
+                JSONStr.cbegin(),
+                JSONStr.cend(),
+                contentType.cbegin(),
+                contentType.cend()))
+    {
+        parsePostsJSON();
+        parsed = true;
+    }
 
     return parsed;
+}
+
+template void Fastcgipp::Http::Environment<char>::parsePostsJSON();
+template void Fastcgipp::Http::Environment<wchar_t>::parsePostsJSON();
+template<class charT>
+void Fastcgipp::Http::Environment<charT>::parsePostsJSON()
+{
+    std::basic_string<charT> value;
+    std::basic_string<charT> name;
+    std::vector<char> name_buffer;
+    name_buffer.push_back('d');
+    name_buffer.push_back('a');
+    name_buffer.push_back('t');
+    name_buffer.push_back('a');
+    vecToString(name_buffer.cbegin(), name_buffer.cend(), name);
+    vecToString(m_postBuffer.cbegin(), m_postBuffer.cend(), value);
+    posts.insert(std::make_pair(std::move(name),std::move(value)));
 }
 
 template void Fastcgipp::Http::Environment<char>::parsePostsMultipart();


### PR DESCRIPTION
Dear Eddie Carle,

I've been getting really frustrated each time I received a json post, which resulted in a "500 Internal server error". So I wrote this quick hack to supply a json-style post to the application in a "data" post field.

Users should be able to use any of the numerous json parsing libraries on github to deal with the "data".

This is in no shape or form a proper json post support, but at least it works now.

Cheers,
Commaster