### PR TITLE
Fix crash when client closes connection

### DIFF
--- a/src/manager.cpp
+++ b/src/manager.cpp
@@ -384,7 +384,9 @@ void Fastcgipp::Manager_base::push(Protocol::RequestId id, Message&& message)
 #endif
         std::unique_lock<std::shared_timed_mutex> lock(m_requestsMutex);
         auto request = m_requests.find(id);
-        if(request == m_requests.end())
+        if(request != m_requests.end())
+            request->second->push(std::move(message));
+        else
         {
             const Protocol::Header& header=
                 *reinterpret_cast<Protocol::Header*>(message.data.data());
@@ -415,8 +417,6 @@ void Fastcgipp::Manager_base::push(Protocol::RequestId id, Message&& message)
                         " doesn't exist")
             return;
         }
-        else
-            request->second->push(std::move(message));
     }
     std::lock_guard<std::mutex> lock(m_tasksMutex);
     m_tasks.push(id);

--- a/src/manager.cpp
+++ b/src/manager.cpp
@@ -386,7 +386,7 @@ void Fastcgipp::Manager_base::push(Protocol::RequestId id, Message&& message)
         auto request = m_requests.find(id);
         if(request != m_requests.end())
             request->second->push(std::move(message));
-        else
+        else if(!message.type)
         {
             const Protocol::Header& header=
                 *reinterpret_cast<Protocol::Header*>(message.data.data());
@@ -417,6 +417,8 @@ void Fastcgipp::Manager_base::push(Protocol::RequestId id, Message&& message)
                         " doesn't exist")
             return;
         }
+        else
+            return;
     }
     std::lock_guard<std::mutex> lock(m_tasksMutex);
     m_tasks.push(id);


### PR DESCRIPTION
The crash occurs when the request is not in the fastcgipp's std::map anymore, and application code sends an empty Fastcgipp::Message(1).