### PR TITLE
CMakeLists.txt: Don't squash flags already set in CMAKE_CXX_FLAGS*

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -56,11 +56,11 @@ endif()
 # Set compile flags for gcc and clang
 if(UNIX)
     set(CMAKE_CXX_FLAGS
-        "$ENV{CXXFLAGS} -std=c++14 -Wall -Werror -Wold-style-cast -pthread")
+        "${CMAKE_CXX_FLAGS} $ENV{CXXFLAGS} -std=c++14 -Wall -Werror -Wold-style-cast -pthread")
     set(CMAKE_CXX_FLAGS_RELEASE
-        "$ENV{CXXFLAGS} -O3 -fomit-frame-pointer -std=c++14 -Wall -Werror -Wold-style-cast -pthread")
+        "${CMAKE_CXX_FLAGS_RELEASE} $ENV{CXXFLAGS} -O3 -fomit-frame-pointer -std=c++14 -Wall -Werror -Wold-style-cast -pthread")
     set(CMAKE_CXX_FLAGS_DEBUG
-        "$ENV{CXXFLAGS} -Og -fno-omit-frame-pointer -g -ggdb -std=c++14 -Wall -Werror -Wold-style-cast -pthread")
+        "${CMAKE_CXX_FLAGS_DEBUG} $ENV{CXXFLAGS} -Og -fno-omit-frame-pointer -g -ggdb -std=c++14 -Wall -Werror -Wold-style-cast -pthread")
 endif()
 
 # Our configuration


### PR DESCRIPTION
Instead we append onto them, this is done so that if this project is included
by something else, which has already set some flags (cross compiling),
they won't be removed unexpectedly.