### PR TITLE
Fixed compile error (gcc 7.1.1) in include/html.hpp

### DIFF
--- a/include/fastcgi++/http.hpp
+++ b/include/fastcgi++/http.hpp
@@ -726,7 +726,7 @@ Out Fastcgipp::Http::base64Decode(In start, In end, Out destination)
 {
     Out dest=destination;
 
-    for(int buffer, bitPos=-8, padStart; start!=end || bitPos>-6; ++dest)
+    for(int buffer=0, bitPos=-8, padStart=0; start!=end || bitPos>-6; ++dest)
     {
         if(bitPos==-8)
         {


### PR DESCRIPTION
Following the build instructions, I got 2 compilation errors, both about variables ("buffer" and "padStart") on the same line in the file http.hpp. The variables could  possibly be used without an initialisation. 
Fix is to initialise these variables at their declaration.