### PR TITLE
use dynamic_cast

### DIFF
--- a/include/fastcgi++/manager.hpp
+++ b/include/fastcgi++/manager.hpp
@@ -300,7 +300,8 @@ namespace Fastcgipp
             using namespace std::placeholders;
 
             std::unique_ptr<Request_base> request(new RequestT);
-            static_cast<RequestT&>(*request).configure(
+            //static_cast<RequestT&>(*request).configure(
+            dynamic_cast<RequestT&>(*request).configure(
                     id,
                     role,
                     kill,


### PR DESCRIPTION
use dynamic_cast, see https://stackoverflow.com/questions/3747066/c-cannot-convert-from-base-a-to-derived-type-b-via-virtual-base-a