### PR TITLE
Use struct instead of class tag for explicit template instantiation

### DIFF
--- a/src/http.cpp
+++ b/src/http.cpp
@@ -623,8 +623,8 @@ void Fastcgipp::Http::Environment<charT>::parsePostsUrlEncoded()
             posts);
 }
 
-template class Fastcgipp::Http::Environment<char>;
-template class Fastcgipp::Http::Environment<wchar_t>;
+template struct Fastcgipp::Http::Environment<char>;
+template struct Fastcgipp::Http::Environment<wchar_t>;
 
 Fastcgipp::Http::SessionId::SessionId()
 {


### PR DESCRIPTION
After trying to compile fastcgipp with a more recent version of clang (6.0 in this case) I encountered several warnings, which resulted in fatal errors thanks to `-Werror`. This pull request fixes #35 where those warnings were already reported.

```
[...]/fastcgipp/src/http.cpp:626:10: error: class template 'Environment' was previously declared as a
      struct template [-Werror,-Wmismatched-tags]
template class Fastcgipp::Http::Environment<char>;
         ^
[...]/fastcgipp/include/fastcgi++/http.hpp:251:38: note: previous use is here
        template<class charT> struct Environment
                                     ^
[...]/fastcgipp/src/http.cpp:626:10: note: did you mean struct here?
template class Fastcgipp::Http::Environment<char>;
         ^~~~~
         struct
[...]/fastcgipp/src/http.cpp:627:10: error: class template 'Environment' was previously declared as a
      struct template [-Werror,-Wmismatched-tags]
template class Fastcgipp::Http::Environment<wchar_t>;
         ^
[...]/fastcgipp/include/fastcgi++/http.hpp:251:38: note: previous use is here
        template<class charT> struct Environment
                                     ^
[...]/fastcgipp/src/http.cpp:627:10: note: did you mean struct here?
template class Fastcgipp::Http::Environment<wchar_t>;
         ^~~~~
         struct
```