### PR TITLE
Remove undefined behaviour caused by dereferencing nullptr

### DIFF
--- a/include/fastcgi++/sockets.hpp
+++ b/include/fastcgi++/sockets.hpp
@@ -251,7 +251,7 @@ namespace Fastcgipp
         //! Returns true if this socket is still open and capable of read/write.
         bool valid() const
         {
-            return m_data->m_valid;
+            return m_data && m_data->m_valid;
         }
 
         //! Call this to close the socket

--- a/src/sockets.cpp
+++ b/src/sockets.cpp
@@ -644,7 +644,7 @@ void Fastcgipp::SocketGroup::createSocket(const socket_t listener)
 }
 
 Fastcgipp::Socket::Socket():
-    m_data(new Data(-1, false, *static_cast<SocketGroup*>(nullptr))),
+    m_data(nullptr),
     m_original(false)
 {}
 


### PR DESCRIPTION
This PR fixes the problem already reported in issue #37, which causes clang 6.0 compilation to fail with because of `-Wnull-dereference`:

```
[...]/fastcgipp/src/sockets.cpp:647:32: error: binding dereferenced null pointer to reference has undefined behavior [-Werror,-Wnull-dereference]
    m_data(new Data(-1, false, *static_cast<SocketGroup*>(nullptr))),
                               ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
```

This is definitely undefined behaviour and might cause optimizers to cause random problems.

I'm not 100% sure, whether this has any unintended side effects, but all instances I found referencing the shared pointer are checking valid() before anyway.
The tests pass successfully and my programs using fastcgipp still work without any problems as well.