### PR TITLE
Don't explicitly cast at all

### DIFF
--- a/include/fastcgi++/manager.hpp
+++ b/include/fastcgi++/manager.hpp
@@ -299,8 +299,8 @@ namespace Fastcgipp
         {
             using namespace std::placeholders;
 
-            std::unique_ptr<Request_base> request(new RequestT);
-            static_cast<RequestT&>(*request).configure(
+            std::unique_ptr<RequestT> request(new RequestT);
+            request->configure(
                     id,
                     role,
                     kill,


### PR DESCRIPTION
`std::unique_ptr` has a special constructor from constructing from a `std::unique_ptr` where the pointer is implicitly convertible and the deleter is implicitly convertible. This should let you remove the PR #38. 