### PR TITLE
Silence warning on EAGAIN or EWOULDBLOCK

### DIFF
--- a/src/sockets.cpp
+++ b/src/sockets.cpp
@@ -104,10 +104,10 @@ ssize_t Fastcgipp::Socket::write(const char* buffer, size_t size) const
     const ssize_t count = ::send(m_data->m_socket, buffer, size, MSG_NOSIGNAL);
     if(count<0)
     {
+        if(errno == EAGAIN || errno == EWOULDBLOCK)
+            return 0;
         WARNING_LOG("Socket write() error on fd " \
                 << m_data->m_socket << ": " << strerror(errno))
-        if(errno == EAGAIN)
-            return 0;
         close();
         return -1;
     }


### PR DESCRIPTION
From man 2 write:
POSIX.1-2001 allows either error to be returned for this case, and  does  not require these constants to have the same valueEAGAIN and EWOULDBLOCK are not required to be the same

I have this happen every now and then and it generates well over a thousand lines of warnings when it happens.