### PR TITLE
Fix dump istream

### DIFF
--- a/src/fcgistreambuf.cpp
+++ b/src/fcgistreambuf.cpp
@@ -209,7 +209,7 @@ void Fastcgipp::FcgiStreambuf<charT, traits>::dump(
             record.size()-header.contentLength-sizeof(Protocol::Header);
 
         send(m_id.m_socket, std::move(record));
-    } while(stream.gcount() < maxContentLength);
+    } while(stream);
 }
 
 template class Fastcgipp::FcgiStreambuf<wchar_t, std::char_traits<wchar_t>>;

--- a/src/sockets.cpp
+++ b/src/sockets.cpp
@@ -104,10 +104,10 @@ ssize_t Fastcgipp::Socket::write(const char* buffer, size_t size) const
     const ssize_t count = ::send(m_data->m_socket, buffer, size, MSG_NOSIGNAL);
     if(count<0)
     {
+        if(errno == EAGAIN || errno == EWOULDBLOCK)
+            return 0;
         WARNING_LOG("Socket write() error on fd " \
                 << m_data->m_socket << ": " << strerror(errno))
-        if(errno == EAGAIN)
-            return 0;
         close();
         return -1;
     }


### PR DESCRIPTION
gcount() sometimes will be < maxContentLength before the end of file