### PR TITLE
WIP constexpr all the things

### DIFF
--- a/include/fastcgi++/sockets.hpp
+++ b/include/fastcgi++/sockets.hpp
@@ -200,13 +200,13 @@ namespace Fastcgipp
         ssize_t write(const char* buffer, size_t size) const;
 
         //! We need this to allow the socket objects to be in sorted containers.
-        bool operator<(const Socket& x) const
+        inline bool operator<(const Socket& x) const noexcept
         {
             return m_data < x.m_data;
         }
 
         //! We need this to allow the socket objects to be in sorted containers.
-        bool operator==(const Socket& x) const
+        inline bool operator==(const Socket& x) const noexcept
         {
             return m_data == x.m_data;
         }


### PR DESCRIPTION
protocol.hpp:
Add toBigEndian and fromBigEndian functions which GCC 8.1 optimizes into bswap
GCC < 8.1 or clang 6.0.0 only optimize fromBigEndian
We could do better, but need to know endianness either with endian.h or C++20's proposed std::endian
Use std::copy_n instead of std::copy
Add noexcept where appropriate (only on inline or constexpr since C++17 changes ABI)