### PR TITLE
WIP Constexpr

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -22,7 +22,8 @@ set(TESTS
     "http"
     "sockets"
     "transceiver"
-    "fcgistreambuf")
+    "fcgistreambuf"
+    "endian")
 set(EXAMPLES
     "helloworld"
     "echo"
@@ -85,6 +86,7 @@ install(FILES
     "${CMAKE_CURRENT_SOURCE_DIR}/include/fastcgi++/sockets.hpp"
     "${CMAKE_CURRENT_SOURCE_DIR}/include/fastcgi++/transceiver.hpp"
     "${CMAKE_CURRENT_SOURCE_DIR}/include/fastcgi++/webstreambuf.hpp"
+    "${CMAKE_CURRENT_SOURCE_DIR}/include/fastcgi++/endian.hpp"
     DESTINATION "include/fastcgi++")
 
 # Build the library itself

--- a/include/fastcgi++/endian.hpp
+++ b/include/fastcgi++/endian.hpp
@@ -144,15 +144,15 @@ namespace Fastcgipp
     constexpr U toBigEndian(U v, OtherEndianTag) noexcept
     {
         union {
-            U i;
+            U u;
             std::uint8_t b[sizeof(U)];
-        } ret = { .i = 0 };
-        for(int i = sizeof(U); i != 0; )
+        } ret = { .u = 0 };
+        for(unsigned i = sizeof(U); i != 0; )
         {
             ret.b[--i] = static_cast<std::uint8_t>(v & 0xff);
             v >>= 8;
         }
-        return ret.i;
+        return ret.u;
     }
     template<class U,
         typename = typename std::enable_if<
@@ -181,16 +181,16 @@ namespace Fastcgipp
     template<class U,
         typename = typename std::enable_if<
             detail::IsByteSwappable<U>::value>::type>
-    constexpr U fromBigEndian(U u, OtherEndianTag) noexcept
+    constexpr U fromBigEndian(U v, OtherEndianTag) noexcept
     {
         union {
-            U i;
+            U u;
             std::uint8_t b[sizeof(U)];
-        } un = { .i = u };
+        } un = { .u = v };
         U ret = 0;
-        for(int i = 0; i < sizeof(U); ++i)
+        for(unsigned i = 0; i < sizeof(U); ++i)
             ret = (ret << 8) | un.b[i];
-        return ret.i;
+        return ret;
     }
     template<class U,
         typename = typename std::enable_if<

--- a/include/fastcgi++/endian.hpp
+++ b/include/fastcgi++/endian.hpp
@@ -1,0 +1,204 @@
+/*!
+ * @file       endian.hpp
+ * @brief      Helper file for converting native and big endian numbers
+ * @author     Aaron Bishop &lt;erroneous@gmail.com&gt;
+ * @date       June 7, 2018
+ * @copyright  Copyright &copy; 2017 Eddie Carle. This project is released under
+ *             the GNU Lesser General Public License Version 3.
+ */
+
+/*******************************************************************************
+* Copyright (C) 2018 Aaron Bishop [erroneous@gmail.com]                             *
+*                                                                              *
+* This file is part of fastcgi++.                                              *
+*                                                                              *
+* fastcgi++ is free software: you can redistribute it and/or modify it under   *
+* the terms of the GNU Lesser General Public License as  published by the Free *
+* Software Foundation, either version 3 of the License, or (at your option)    *
+* any later version.                                                           *
+*                                                                              *
+* fastcgi++ is distributed in the hope that it will be useful, but WITHOUT ANY *
+* WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS    *
+* FOR A PARTICULAR PURPOSE.  See the GNU Lesser General Public License for     *
+* more details.                                                                *
+*                                                                              *
+* You should have received a copy of the GNU Lesser General Public License     *
+* along with fastcgi++.  If not, see <http://www.gnu.org/licenses/>.           *
+*******************************************************************************/
+
+#ifndef FASTCGIPP_ENDIAN_HPP
+#define FASTCGIPP_ENDIAN_HPP
+
+#include <cstdint>
+#include <type_traits>
+
+#ifdef BSD
+#include <sys/endian.h>
+#elif defined (__unix__) || (defined (__APPLE__) && defined (__MACH__))
+#include <endian.h>
+#elif defined(WIN32) && (defined(_M_IX86) || defined(_M_X64))
+#define BIG_ENDIAN 1234
+#define LITTLE_ENDIAN 4321
+#define BYTE_ORDER LITTLE_ENDIAN
+#endif
+
+#ifndef BIG_ENDIAN
+#if defined(__BIG_ENDIAN)
+#define BIG_ENDIAN __BIG_ENDIAN
+#elif defined(__BIG_ENDIAN__)
+#define BIG_ENDIAN __BIG_ENDIAN__
+#endif
+#endif
+
+#ifndef LITTLE_ENDIAN
+#if defined(__LITTLE_ENDIAN)
+#define LITTLE_ENDIAN __LITTLE_ENDIAN
+#elif defined(__LITTLE_ENDIAN__)
+#define LITTLE_ENDIAN __LITTLE_ENDIAN__
+#endif
+#endif
+
+#ifndef BYTE_ORDER
+#if defined(__BYTE_ORDER)
+#define BYTE_ORDER __BYTE_ORDER
+#elif defined(__BYTE_ORDER__)
+#define BYTE_ORDER __BYTE_ORDER__
+#endif
+#endif
+
+#if !(defined(BIG_ENDIAN) && defined(LITTLE_ENDIAN) && defined(BYTE_ORDER))
+#error "Please define BIG_ENDIAN, LITTLE_ENDIAN, and BYTE_ORDER"
+#endif
+
+namespace Fastcgipp
+{
+    namespace detail
+    {
+        template<class U>
+        using IsByteSwappable = std::integral_constant<bool,
+            std::is_same<U, std::uint16_t>::value ||
+            std::is_same<U, std::uint32_t>::value ||
+            std::is_same<U, std::uint64_t>::value>;
+    }
+    enum class Endian
+    {
+        little = LITTLE_ENDIAN,
+        big = BIG_ENDIAN,
+        native = BYTE_ORDER
+    };
+    
+    constexpr std::uint16_t byteSwap(const std::uint16_t v) noexcept
+    {
+        return
+            (v & 0xff00) >> 8 |
+            (v & 0x00ff) << 8;
+    }
+    constexpr std::uint32_t byteSwap(const std::uint32_t v) noexcept
+    {
+        return
+            (v & 0xff000000) >> 24 |
+            (v & 0x00ff0000) >> 8 |
+            (v & 0x0000ff00) << 8 |
+            (v & 0x000000ff) << 24;
+    }
+    constexpr std::uint64_t byteSwap(const std::uint64_t v) noexcept
+    {
+        return
+            (v & 0xff00000000000000) >> 56 |
+            (v & 0x00ff000000000000) >> 40 |
+            (v & 0x0000ff0000000000) >> 24 |
+            (v & 0x000000ff00000000) >> 8 |
+            (v & 0x00000000ff000000) << 8 |
+            (v & 0x0000000000ff0000) << 24 |
+            (v & 0x000000000000ff00) << 40 |
+            (v & 0x00000000000000ff) << 56;
+    }
+    template<Endian e>
+    using EndianTag = std::integral_constant<Endian, e>;
+    
+    using BigEndianTag = EndianTag<Endian::big>;
+    using LittleEndianTag = EndianTag<Endian::little>;
+    using OtherEndianTag = EndianTag<static_cast<Endian>(10)>;
+    
+    using NativeEndianTag = EndianTag<Endian::native>;
+
+    template<class U,
+        typename = typename std::enable_if<
+            detail::IsByteSwappable<U>::value>::type>
+    constexpr U toBigEndian(U v, BigEndianTag) noexcept
+    {
+        return v;
+    }
+
+    template<class U,
+        typename = typename std::enable_if<
+            detail::IsByteSwappable<U>::value>::type>
+    constexpr U toBigEndian(U v, LittleEndianTag) noexcept
+    {
+        return byteSwap(v);
+    }
+    
+    template<class U,
+        typename = typename std::enable_if<
+            detail::IsByteSwappable<U>::value>::type>
+    constexpr U toBigEndian(U v, OtherEndianTag) noexcept
+    {
+        union {
+            U i;
+            std::uint8_t b[sizeof(U)];
+        } ret = { .i = 0 };
+        for(int i = sizeof(U); i != 0; )
+        {
+            ret.b[--i] = static_cast<std::uint8_t>(v & 0xff);
+            v >>= 8;
+        }
+        return ret.i;
+    }
+    template<class U,
+        typename = typename std::enable_if<
+            detail::IsByteSwappable<U>::value>::type>
+    constexpr U toBigEndian(U v) noexcept
+    {
+        return toBigEndian(v, NativeEndianTag{});
+    }
+
+    template<class U,
+        typename = typename std::enable_if<
+            detail::IsByteSwappable<U>::value>::type>
+    constexpr U fromBigEndian(U v, BigEndianTag) noexcept
+    {
+        return v;
+    }
+
+    template<class U,
+        typename = typename std::enable_if<
+            detail::IsByteSwappable<U>::value>::type>
+    constexpr U fromBigEndian(U v, LittleEndianTag) noexcept
+    {
+        return byteSwap(v);
+    }
+    
+    template<class U,
+        typename = typename std::enable_if<
+            detail::IsByteSwappable<U>::value>::type>
+    constexpr U fromBigEndian(U u, OtherEndianTag) noexcept
+    {
+        union {
+            U i;
+            std::uint8_t b[sizeof(U)];
+        } un = { .i = u };
+        U ret = 0;
+        for(int i = 0; i < sizeof(U); ++i)
+            ret = (ret << 8) | un.b[i];
+        return ret.i;
+    }
+    template<class U,
+        typename = typename std::enable_if<
+            detail::IsByteSwappable<U>::value>::type>
+    constexpr U fromBigEndian(U v) noexcept
+    {
+        return fromBigEndian(v, NativeEndianTag{});
+    }
+}
+
+#endif

--- a/include/fastcgi++/protocol.hpp
+++ b/include/fastcgi++/protocol.hpp
@@ -214,12 +214,16 @@ namespace Fastcgipp
             typedef typename Unsigned<size>::Type BaseType;
 
             //! The raw data of the big endian integer
-            BaseType m_data = 0;
+            union BaseUnion {
+                BaseType base;
+                T type;
+            } m_data { .base = 0 };
 
             //! Set the internal data to the passed parameter.
-            constexpr void set(BaseType x) noexcept
+            constexpr void set(T x) noexcept
             {
-                m_data = toBigEndian(x);
+                m_data.type = x;
+                m_data.base = toBigEndian(m_data.base);
             }
 
         public:
@@ -239,7 +243,7 @@ namespace Fastcgipp
 
             constexpr operator T() const noexcept
             {
-                return static_cast<T>(fromBigEndian(m_data));
+                return BaseUnion{ .base = fromBigEndian(m_data.base)}.type;
             }
 
             //! Static function for reading the value out of a data array.
@@ -258,7 +262,7 @@ namespace Fastcgipp
                 } u = { .base = 0};
                 for(auto& b : u.actual)
                     b = *source++;
-                return static_cast<T>(fromBigEndian(u.base));
+                return BaseUnion{ .base = fromBigEndian(u.base)}.type;
             }
 
             //! Simply casts char to std::uint8_t.

--- a/include/fastcgi++/sockets.hpp
+++ b/include/fastcgi++/sockets.hpp
@@ -200,13 +200,13 @@ namespace Fastcgipp
         ssize_t write(const char* buffer, size_t size) const;
 
         //! We need this to allow the socket objects to be in sorted containers.
-        bool operator<(const Socket& x) const
+        inline bool operator<(const Socket& x) const noexcept
         {
             return m_data < x.m_data;
         }
 
         //! We need this to allow the socket objects to be in sorted containers.
-        bool operator==(const Socket& x) const
+        inline bool operator==(const Socket& x) const noexcept
         {
             return m_data == x.m_data;
         }

--- a/tests/endian.cpp
+++ b/tests/endian.cpp
@@ -16,11 +16,16 @@ int main()
     } u = { .b = {1, 2, 3, 4} };
     if(fromBigEndian(u.i) != 0x01020304)
         FAIL_LOG("Failed fromBigEndian");
+    if(fromBigEndian(u.i, OtherEndianTag{}) != 0x01020304)
+        FAIL_LOG("Failed fromBigEndian Other");
     if(byteSwap(byteSwap(0x01020304u)) != 0x01020304)
         FAIL_LOG("Failed byteSwap");
     u.i = toBigEndian(0x01020304u);
     if(u.b[0] != 1 || u.b[1] != 2 || u.b[2] != 3 || u.b[3] != 4)
         FAIL_LOG("Failed toBigEndian");
+    u.i = toBigEndian(0x01020304u, OtherEndianTag{});
+    if(u.b[0] != 1 || u.b[1] != 2 || u.b[2] != 3 || u.b[3] != 4)
+        FAIL_LOG("Failed toBigEndian Other");
 
     return 0;
 }

--- a/tests/endian.cpp
+++ b/tests/endian.cpp
@@ -1,0 +1,26 @@
+#include "fastcgi++/log.hpp"
+#include "fastcgi++/endian.hpp"
+
+using namespace Fastcgipp;
+using namespace Fastcgipp::detail;
+
+int main()
+{
+    static_assert(IsByteSwappable<std::uint16_t>::value, "IsByteSwappable");
+    static_assert(IsByteSwappable<std::uint32_t>::value, "IsByteSwappable");
+    static_assert(IsByteSwappable<std::uint64_t>::value, "IsByteSwappable");
+
+    union {
+        std::uint32_t i;
+        std::uint8_t b[4];
+    } u = { .b = {1, 2, 3, 4} };
+    if(fromBigEndian(u.i) != 0x01020304)
+        FAIL_LOG("Failed fromBigEndian");
+    if(byteSwap(byteSwap(0x01020304u)) != 0x01020304)
+        FAIL_LOG("Failed byteSwap");
+    u.i = toBigEndian(0x01020304u);
+    if(u.b[0] != 1 || u.b[1] != 2 || u.b[2] != 3 || u.b[3] != 4)
+        FAIL_LOG("Failed toBigEndian");
+
+    return 0;
+}


### PR DESCRIPTION
More BigEndian changes.
Add endian.hpp to separate out logic
Adds C++20 style Endian enum
Use single bswap (with optimization) on clang/gcc for x86_64
Add tests to verify to/from big endian works.