### PR TITLE
Add non-const accessor for m_environment

### DIFF
--- a/include/fastcgi++/request.hpp
+++ b/include/fastcgi++/request.hpp
@@ -154,6 +154,10 @@ namespace Fastcgipp
         {
             return m_environment;
         }
+        Http::Environment<charT>& environment()
+        {
+            return m_environment;
+        }
 
         //! Standard output stream to the client
         std::basic_ostream<charT> out;


### PR DESCRIPTION
Allows moving the environment safely to a thread. Without being able to copy (can't because `File<charT>` can't be copied) or move the `Environment<charT>`, you can only reference it which might segfault because it will be destroyed if the connection closes.

In my case I just do something like:
```c++
void do_request(
	const std::function<void(Fastcgipp::Message)> callback,
	Fastcgipp::Http::Environment<char> env,
	std::shared_ptr<bool> cancel_token);
//...inside response()
	auto c = std::make_shared<bool>(true);
	cancel_token = c;
	thread_pool.enqueue([this,&c]() {
		do_request(callback(), std::move(environment()), std::move(c));
	});
```