### PR TITLE
Adding a handler for posts with unknown content-type

### DIFF
--- a/include/fastcgi++/request.hpp
+++ b/include/fastcgi++/request.hpp
@@ -184,6 +184,14 @@ namespace Fastcgipp
          */
         virtual void bigPostErrorHandler();
 
+        //! Called when receiving an unknown content type
+        /*!
+         * This function is called when the client sends an unknown content
+         * type. By default it will send a standard 415 Unsupported Media Type
+         * message to the user.  Override for more specialized purposes.
+         */
+        virtual void unknownContentErrorHandler();
+
         //! See the requests role
         Protocol::Role role() const
         {

--- a/src/request.cpp
+++ b/src/request.cpp
@@ -122,7 +122,7 @@ std::unique_lock<std::mutex>Fastcgipp::Request<charT>::handler()
                         if(!inProcessor() && !m_environment.parsePostBuffer())
                         {
                             WARNING_LOG("Unknown content type from client")
-                            errorHandler();
+                            unknownContentErrorHandler();
                             complete();
                             goto exit;
                         }
@@ -196,6 +196,22 @@ template<class charT> void Fastcgipp::Request<charT>::bigPostErrorHandler()
     "</head>"\
     "<body>"\
         "<h1>413 Request Entity Too Large</h1>"\
+    "</body>"\
+"</html>";
+}
+
+template<class charT> void Fastcgipp::Request<charT>::unknownContentErrorHandler()
+{
+        out << \
+"Status: 415 Unsupported Media Type\n"\
+"Content-Type: text/html; charset=utf-8\r\n\r\n"\
+"<!DOCTYPE html>"\
+"<html lang='en'>"\
+    "<head>"\
+        "<title>415 Unsupported Media Type</title>"\
+    "</head>"\
+    "<body>"\
+        "<h1>415 Unsupported Media Type</h1>"\
     "</body>"\
 "</html>";
 }


### PR DESCRIPTION
For consistency I propose this modification that changes the returned HTTP status from 500 (Internal Server Error) to 415 (Unsupported Media Type) when the client posts unhandled content types.
