### PR TITLE
New method resizeThreads to change the number of threads in Manager_base

### DIFF
--- a/include/fastcgi++/manager.hpp
+++ b/include/fastcgi++/manager.hpp
@@ -182,6 +182,17 @@ namespace Fastcgipp
             m_transceiver.reuseAddress(value);
         }
 
+        //! Call before start to change the number of threads
+        /*!
+         * If the Manager is already running this will do nothing.
+         *
+         * @param[in] threads Number of threads to use for request handling
+         *
+         * @sa Manager_base()
+         * @sa start()
+         */
+        void resizeThreads(unsigned threads);
+
     protected:
         //! Make a request object
         virtual std::unique_ptr<Request_base> makeRequest(

--- a/src/manager.cpp
+++ b/src/manager.cpp
@@ -414,6 +414,17 @@ void Fastcgipp::Manager_base::push(Protocol::RequestId id, Message&& message)
     m_wake.notify_one();
 }
 
+void Fastcgipp::Manager_base::resizeThreads(unsigned threads)
+{
+    if(m_stop)
+    {
+        m_threads.resize(threads);
+#if FASTCGIPP_LOG_LEVEL > 3
+        m_activeThreads = threads;
+#endif
+    }
+}
+
 Fastcgipp::Manager_base::~Manager_base()
 {
     instance=nullptr;


### PR DESCRIPTION
Hi,

I added the ability to change the number of worker threads in Manager_base outside of the constructor.

This because I store this parameter in a config file, and I have initialization dependency problems between the various objects. This allows more flexibility when creating the manager.
