### PR TITLE
Change position of virtual in Request::inProcessor declaration

### DIFF
--- a/include/fastcgi++/request.hpp
+++ b/include/fastcgi++/request.hpp
@@ -262,7 +262,7 @@ namespace Fastcgipp
          *
          * @return Return true if you've processed the data.
          */
-        bool virtual inProcessor()
+        virtual bool inProcessor()
         {
             return false;
         }


### PR DESCRIPTION
The parser of CLion (which uses clang, as far as I know) does not recognize the inProcessor() function of Fastcgipp::Request as virtual and shows a warning when trying to override it. This can be fixed by changing it from "bool virtual" to "virtual bool".