### PR TITLE
Avoid -Winvalid-source-encoding warnings

### DIFF
--- a/examples/sessions.cpp
+++ b/examples/sessions.cpp
@@ -122,8 +122,8 @@ class Sessions: public Fastcgipp::Request<char>
                 "enctype='application/x-www-form-urlencoded' "
                 "accept-charset='ISO-8859-1'>"
             "<div>"
-                "Text: <input type='text' name='data' value='Hola señor, usted "
-                    "me almacenó en una sesión' />"
+                "Text: <input type='text' name='data' value='Hola se" "\xf1" "or, usted "
+                    "me almacen" "\xf3" " en una sesi" "\xf3" "n' />"
                 "<input type='submit' name='submit' value='submit' />"
             "</div>"
         "</form>";


### PR DESCRIPTION
Hello and thanks for fastcgipp,
  Compiling with clang++ v5 produced -Werror,-Winvalid-source-encoding warnings as errors on these characters, using the hex code avoids the warning.

```
fastcgipp-3.0/examples/sessions.cpp:105:57: error: illegal character encoding in string literal
      [-Werror,-Winvalid-source-encoding]
                                "Text: <input type='text' name='data' value='Hola se<F1>or, usted "
                                                                                    ^~~~
fastcgipp-3.0/examples/sessions.cpp:106:32: error: illegal character encoding in string literal
      [-Werror,-Winvalid-source-encoding]
                    "me almacen<F3> en una sesi<F3>n' />"
                               ^~~~            ~~~~
2 errors generated.
```