### PR TITLE
Fix wrong include dir in CMake export file

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -129,7 +129,7 @@ endif(UNIX)
 
 include(GNUInstallDirs)
 target_include_directories(fastcgipp PUBLIC
-    $<INSTALL_INTERFACE:${CMAKE_INSTALL_LIBDIR}>
+    $<INSTALL_INTERFACE:${CMAKE_INSTALL_INCLUDEDIR}>
     $<BUILD_INTERFACE:${CMAKE_CURRENT_BINARY_DIR}/include>
     $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/include>)
 


### PR DESCRIPTION
fastcgi exporting `${PREFIX}/lib` as include directory. If `${PREFIX}` is `/usr`, it doesn't matter
because /usr/include is included by default, but it doesn't work if other PREFIX chosen.

This PR fixes the issue and makes FastcgippConfig.cmake working even if very specific PREFIX chosen.