### PR TITLE
Add missing <condition_variable> include

### DIFF
--- a/include/fastcgi++/manager.hpp
+++ b/include/fastcgi++/manager.hpp
@@ -37,6 +37,7 @@
 #include <shared_mutex>
 #include <memory>
 #include <functional>
+#include <condition_variable>
 
 #include "fastcgi++/protocol.hpp"
 #include "fastcgi++/transceiver.hpp"


### PR DESCRIPTION
I just tried to compile a project using fastcgi++ with the latest gcc master.

Unfortunately that failed due to the missing `<condition_variable>` include in manager.hpp.

This short PR just adds that missing include.