### PR TITLE
Manager::reuseAddress(true) does not have an effect

### DIFF
--- a/src/sockets.cpp
+++ b/src/sockets.cpp
@@ -187,11 +187,12 @@ Fastcgipp::SocketGroup::~SocketGroup()
 static void set_reuse(int sock)
 {
 #if defined(FASTCGIPP_LINUX) || defined(FASTCGIPP_UNIX)
+    int x = 1;
     if(::setsockopt(
         sock,
         SOL_SOCKET,
         SO_REUSEADDR,
-        reinterpret_cast<int*>(1),
+        &x,
         sizeof(int)) != 0)
         WARNING_LOG("Socket setsockopt(SO_REUSEADDR, 1) error on fd " \
                 << sock << ": " << strerror(errno))


### PR DESCRIPTION
in set_reuse, a parameter is incorrectly passed to setsockopt, which causes error and leaves option not set, so for example when socket is in WAIT_STATE, application is not able to bind to it.