### PR TITLE
Fix compile error with Clang

### DIFF
--- a/include/fastcgi++/curl.hpp
+++ b/include/fastcgi++/curl.hpp
@@ -220,6 +220,9 @@ namespace Fastcgipp
         {
             return m_streamBuf->m_errorBuffer;
         }
+
+        virtual ~Curl_base()
+        {};
     };
 
     //! Object for composing curl messages


### PR DESCRIPTION
Because **Curl_base** has virtual functions, it should have a virtual destructor. This is enforced by **Clang** warning option `delete-non-abstract-non-virtual-dtor`, included in `all`.

Full error log when compiling:
```
In file included from /home/pierre/sources/fastcgipp/src/curler.cpp:28:
In file included from /home/pierre/sources/fastcgipp/include/fastcgi++/curler.hpp:31:
In file included from /usr/bin/../lib/gcc/x86_64-linux-gnu/9/../../../../include/c++/9/queue:60:
In file included from /usr/bin/../lib/gcc/x86_64-linux-gnu/9/../../../../include/c++/9/deque:64:
In file included from /usr/bin/../lib/gcc/x86_64-linux-gnu/9/../../../../include/c++/9/bits/allocator.h:46:
In file included from /usr/bin/../lib/gcc/x86_64-linux-gnu/9/../../../../include/x86_64-linux-gnu/c++/9/bits/c++allocator.h:33:
/usr/bin/../lib/gcc/x86_64-linux-gnu/9/../../../../include/c++/9/ext/new_allocator.h:153:4: error: destructor called on non-final 'Fastcgipp::Curl_base' that has virtual functions but non-virtual destructor [-Werror,-Wdelete-non-abstract-non-virtual-dtor]
        { __p->~_Up(); }
          ^
/usr/bin/../lib/gcc/x86_64-linux-gnu/9/../../../../include/c++/9/bits/alloc_traits.h:497:8: note: in instantiation of function template specialization '__gnu_cxx::new_allocator<Fastcgipp::Curl_base>::destroy<Fastcgipp::Curl_base>' requested here
        { __a.destroy(__p); }
              ^
/usr/bin/../lib/gcc/x86_64-linux-gnu/9/../../../../include/c++/9/bits/stl_deque.h:1611:21: note: in instantiation of function template specialization 'std::allocator_traits<std::allocator<Fastcgipp::Curl_base> >::destroy<Fastcgipp::Curl_base>' requested here
            _Alloc_traits::destroy(this->_M_impl,
                           ^
/usr/bin/../lib/gcc/x86_64-linux-gnu/9/../../../../include/c++/9/bits/stl_queue.h:295:4: note: in instantiation of member function 'std::deque<Fastcgipp::Curl_base, std::allocator<Fastcgipp::Curl_base> >::pop_front' requested here
        c.pop_front();
          ^
/home/pierre/sources/fastcgipp/src/curler.cpp:51:25: note: in instantiation of member function 'std::queue<Fastcgipp::Curl_base, std::deque<Fastcgipp::Curl_base, std::allocator<Fastcgipp::Curl_base> > >::pop' requested here
                m_queue.pop();delete-non-abstract-non-virtual-dtor
```