### PR TITLE
Fixes/build warnings

### DIFF
--- a/examples/email.cpp
+++ b/examples/email.cpp
@@ -7,7 +7,7 @@ class EmailSender: public Fastcgipp::Request<wchar_t>
 
     inline bool send();
 
-    bool response()
+    virtual bool response()
     {
         out <<
 L"Content-Type: text/html; charset=utf-8\r\n\r\n"

--- a/include/fastcgi++/chunkstreambuf.hpp
+++ b/include/fastcgi++/chunkstreambuf.hpp
@@ -86,7 +86,7 @@ namespace Fastcgipp
         //! Empty/flush the buffer
         bool emptyBuffer();
 
-        ~ChunkStreamBuf()
+        virtual ~ChunkStreamBuf()
         {
             emptyBuffer();
         }
@@ -109,7 +109,7 @@ namespace Fastcgipp
         //! Empty/flush the buffer
         bool emptyBuffer();
 
-        ~ChunkStreamBuf()
+        virtual ~ChunkStreamBuf()
         {
             emptyBuffer();
         }

--- a/include/fastcgi++/curler.hpp
+++ b/include/fastcgi++/curler.hpp
@@ -87,7 +87,7 @@ namespace Fastcgipp
         //! Queue up an curl
         void queue(Curl_base& curl);
 
-        ~Curler();
+        virtual ~Curler();
 
         //! Construct a Curler object
         /*!

--- a/include/fastcgi++/email.hpp
+++ b/include/fastcgi++/email.hpp
@@ -94,7 +94,7 @@ namespace Fastcgipp
                 close();
                 return std::move(m_data);
             }
-
+            virtual ~Email_base() = default;
         protected:
             //! %Email message data
             DataRef m_data;
@@ -132,6 +132,7 @@ namespace Fastcgipp
 
         public:
             Email();
+            ~Email() override = default;
 
             //! Set the to address
             void to(const std::basic_string<charT>& address);

--- a/include/fastcgi++/fcgistreambuf.hpp
+++ b/include/fastcgi++/fcgistreambuf.hpp
@@ -60,7 +60,7 @@ namespace Fastcgipp
             this->setp(m_buffer, m_buffer+s_buffSize);
         }
 
-        ~FcgiStreambuf()
+        virtual ~FcgiStreambuf()
         {
             emptyBuffer();
         }

--- a/include/fastcgi++/mailer.hpp
+++ b/include/fastcgi++/mailer.hpp
@@ -107,7 +107,7 @@ namespace Fastcgipp
                     const unsigned short port=25,
                     unsigned retryInterval=30);
 
-            ~Mailer();
+            virtual ~Mailer();
 
             Mailer():
                 m_initialized(false),

--- a/include/fastcgi++/manager.hpp
+++ b/include/fastcgi++/manager.hpp
@@ -70,7 +70,7 @@ namespace Fastcgipp
          */
         Manager_base(unsigned threads);
 
-        ~Manager_base();
+        virtual ~Manager_base();
 
         //! Call from any thread to terminate the Manager
         /*!

--- a/include/fastcgi++/poll.hpp
+++ b/include/fastcgi++/poll.hpp
@@ -169,7 +169,7 @@ namespace Fastcgipp
         Result poll(int timeout);
 
         Poll();
-        ~Poll();
+        virtual ~Poll();
     };
 }
 

--- a/include/fastcgi++/request.hpp
+++ b/include/fastcgi++/request.hpp
@@ -244,7 +244,7 @@ namespace Fastcgipp
          * @param[in] bytesReceived Amount of bytes received in this FastCGI
          *                          record
          */
-        virtual void inHandler(int bytesReceived)
+        virtual void inHandler([[maybe_unused]] int bytesReceived)
         {}
 
         //! Process custom POST data

--- a/include/fastcgi++/sockets.hpp
+++ b/include/fastcgi++/sockets.hpp
@@ -225,7 +225,7 @@ namespace Fastcgipp
         }
 
         //! Calls close() on the socket if we are destructing the original
-        ~Socket();
+        virtual ~Socket();
 
         //! Returns true if this socket is still open and capable of read/write.
         bool valid() const
@@ -268,7 +268,7 @@ namespace Fastcgipp
     public:
         SocketGroup();
 
-        ~SocketGroup();
+        virtual ~SocketGroup();
 
         //! Listen to the default Fastcgi socket
         /*!

--- a/include/fastcgi++/sql/connection.hpp
+++ b/include/fastcgi++/sql/connection.hpp
@@ -136,7 +136,7 @@ namespace Fastcgipp
                     int messageType=5432,
                     unsigned retryInterval=30);
 
-            ~Connection();
+            virtual ~Connection();
 
             Connection():
                 m_initialized(false)

--- a/include/fastcgi++/transceiver.hpp
+++ b/include/fastcgi++/transceiver.hpp
@@ -116,7 +116,7 @@ namespace Fastcgipp
                 const std::function<void(Protocol::RequestId, Message&&)>
                 sendMessage);
 
-        ~Transceiver();
+        virtual ~Transceiver();
 
         //! Listen to the default Fastcgi socket
         /*!


### PR DESCRIPTION
The PR solves the [issue#104](https://github.com/eddic/fastcgipp/issues/104)
- Fix inherit base classes without virtual destructors                  
- Prevent `-Wunused-parameter` warning. 